### PR TITLE
Handle viewport changes for quiz page

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -61,8 +61,8 @@ button, input, select, textarea { font: inherit; color: inherit; }
 .backbtn { display: inline-flex; align-items: center; gap: 8px; border: 1px solid var(--border); background: var(--surface); color: var(--fg); border-radius: 999px; padding: 10px 14px; cursor: pointer; font-weight: 700; box-shadow: none; }
 .backbtn:hover { border-color: #cbd5e1; }
 
-.screen { height: calc(100dvh - var(--topbar-h)); display: flex; flex-direction: column; }
-.center-panel { flex: 1; display: grid; place-items: center; padding: 24px; text-align: center; }
+.screen { height: calc(var(--app-h, 100dvh) - var(--topbar-h)); display: flex; flex-direction: column; }
+.center-panel { flex: 1; overflow-y: auto; min-height: 0; display: flex; align-items: center; justify-content: center; padding: clamp(16px, 5vh, 24px); text-align: center; }
 .bottom-bar { position: sticky; left: 0; right: 0; bottom: 0; background: var(--surface); border-top: 1px solid var(--border); box-shadow: 0 -4px 12px rgba(0,0,0,0.04); padding: 12px max(16px, env(safe-area-inset-left)) calc(12px + env(safe-area-inset-bottom)) max(16px, env(safe-area-inset-right)); min-height: var(--bar-h); margin-top: auto; }
 .bottom-inner { max-width: 860px; margin: 0 auto; display: grid; grid-template-columns: 1fr; gap: 10px; }
 

--- a/app/unit/[id]/practice-client.tsx
+++ b/app/unit/[id]/practice-client.tsx
@@ -101,6 +101,22 @@ export default function PracticeClient({ unitId }: { unitId: number }) {
     return () => { /* on unmount */ clearProgress(); };
   }, [done, promptIndex, prompts.length, setProgress, clearProgress]);
 
+  // Dynamic viewport height for mobile browsers
+  useEffect(() => {
+    const root = document.documentElement;
+    const update = () => {
+      const vh = window.visualViewport?.height || window.innerHeight;
+      root.style.setProperty('--app-h', `${vh}px`);
+    };
+    update();
+    window.addEventListener('resize', update);
+    window.visualViewport?.addEventListener('resize', update);
+    return () => {
+      window.removeEventListener('resize', update);
+      window.visualViewport?.removeEventListener('resize', update);
+    };
+  }, []);
+
   const nativeNorm = useCallback((s: string) => s.normalize('NFKC').trim(), []);
   const romanNorm = useCallback((s: string) => s.normalize('NFKC').trim().toLowerCase().replace(/[^a-z0-9]/g, ''), []);
   const isValid = useCallback(() => {


### PR DESCRIPTION
## Summary
- Resize app to the usable viewport so header and input bar stay visible when the keyboard opens
- Allow prompt region to flex and scroll as needed with reduced padding on small screens

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c39e01f2a8832cad3fd648d99765cc