### PR TITLE
Fix progress route params for Next.js 15

### DIFF
--- a/app/api/progress/[unitId]/route.ts
+++ b/app/api/progress/[unitId]/route.ts
@@ -1,14 +1,18 @@
 import { NextRequest, NextResponse } from 'next/server';
 import prisma from '@/lib/prisma';
 
-export async function GET(req: NextRequest, { params }: { params: { unitId: string } }) {
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ unitId: string }> }
+) {
   const deviceId = req.nextUrl.searchParams.get('deviceId');
-  const unitId = Number(params.unitId);
-  if (!deviceId || Number.isNaN(unitId)) {
+  const { unitId } = await params;
+  const unitIdNumber = Number(unitId);
+  if (!deviceId || Number.isNaN(unitIdNumber)) {
     return NextResponse.json({ error: 'Invalid request' }, { status: 400 });
   }
   const progress = await prisma.progress.findUnique({
-    where: { deviceId_unitId: { deviceId, unitId } },
+    where: { deviceId_unitId: { deviceId, unitId: unitIdNumber } },
   });
   if (!progress) {
     return NextResponse.json({ error: 'Not found' }, { status: 404 });


### PR DESCRIPTION
## Summary
- await dynamic route params in progress API handler to match Next.js 15 `params` type

## Testing
- `bun run lint`
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_e_68c3f1aa2a10832c94e21e666a29b653