### PR TITLE
Add skeleton placeholder for unit prompt loading

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -121,11 +121,71 @@ button, input, select, textarea { font: inherit; color: inherit; }
 .progress--topbar { margin: 0; }
 
 /* Prompt card */
-.prompt { font-size: clamp(34px, 7vw, 52px); line-height: 1.2; text-align: center; margin-bottom: 8px; }
+.prompt {
+  font-size: clamp(34px, 7vw, 52px);
+  line-height: 1.2;
+  text-align: center;
+  margin-bottom: 8px;
+  min-height: clamp(120px, 24vh, 180px);
+  display: grid;
+  place-items: center;
+  padding: clamp(16px, 4vw, 24px);
+  animation: fade-up 0.28s ease;
+}
 .actions { display: grid; grid-template-columns: 1fr; gap: 10px; }
 @media (min-width: 480px) { .actions { grid-template-columns: 1fr 1fr; } }
 .actions--single { grid-template-columns: 1fr !important; }
 .actions--single .button { width: 100%; }
+
+.skeleton {
+  position: relative;
+  display: block;
+  width: 100%;
+  border-radius: 16px;
+  background: color-mix(in srgb, var(--muted) 18%, var(--surface));
+  overflow: hidden;
+}
+.skeleton::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  transform: translateX(-100%);
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    color-mix(in srgb, var(--surface) 65%, transparent) 50%,
+    transparent 100%
+  );
+  animation: shimmer 1.4s infinite;
+}
+.loading-placeholder { width: min(520px, 100%); display: grid; gap: 18px; }
+.skeleton--prompt { height: clamp(120px, 24vh, 180px); border-radius: 24px; }
+.skeleton--line { height: 18px; border-radius: 999px; }
+.skeleton--line.skeleton--short { width: 60%; justify-self: center; }
+.skeleton--input,
+.skeleton--button { height: 64px; }
+
+@keyframes shimmer {
+  100% {
+    transform: translateX(100%);
+  }
+}
+
+@keyframes fade-up {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .skeleton::after { animation: none; transform: none; }
+  .prompt { animation: none; }
+}
 
 /* Toasts */
 .toast-container { position: fixed; right: max(16px, env(safe-area-inset-right)); top: calc(env(safe-area-inset-top) + 16px); display: grid; gap: 8px; z-index: 60; }

--- a/app/unit/[id]/practice-client.tsx
+++ b/app/unit/[id]/practice-client.tsx
@@ -209,7 +209,25 @@ export default function PracticeClient({ unitId }: { unitId: number }) {
     }
   }, [reloadPrompts, newAnswer, newContent, unitId, toast]);
 
-  if (loading) return <div className="screen"><div className="center-panel"><p className="muted">Loading prompts...</p></div></div>;
+  if (loading) {
+    return (
+      <div className="screen" aria-busy>
+        <div className="center-panel">
+          <div className="loading-placeholder" aria-label="Loading prompts">
+            <div className="skeleton skeleton--prompt" />
+            <div className="skeleton skeleton--line" />
+            <div className="skeleton skeleton--line skeleton--short" />
+          </div>
+        </div>
+        <div className="bottom-bar">
+          <div className="bottom-inner">
+            <div className="skeleton skeleton--input" />
+            <div className="skeleton skeleton--button" />
+          </div>
+        </div>
+      </div>
+    );
+  }
   if (error) return <div className="screen"><div className="center-panel"><p className="muted" style={{ color: 'crimson' }}>{error}</p></div></div>;
   if (prompts.length === 0) {
     return (


### PR DESCRIPTION
## Summary
- replace the practice loading message with a shimmering skeleton placeholder that matches the layout
- smooth the prompt reveal with a fade-up animation and support reduced-motion preferences

## Testing
- bun run lint

------
https://chatgpt.com/codex/tasks/task_e_68ca457bd8c8832cb18257d60ef3e32a