### PR TITLE
Build arm64-only Docker image in CI

### DIFF
--- a/.github/workflows/build-push-deploy.yml
+++ b/.github/workflows/build-push-deploy.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Set up QEMU (multi-arch)
+      - name: Set up QEMU (arm64 build)
         uses: docker/setup-qemu-action@v3
 
       - name: Log in to GHCR
@@ -59,7 +59,7 @@ jobs:
         with:
           context: .
           push: true
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha


### PR DESCRIPTION
## Summary
- retitle the QEMU setup step to clarify it is only used for arm64 builds
- configure the build-and-push step to produce only a linux/arm64 image

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ccbd34f37c832c82510cc6d2860514