### PR TITLE
Add quality checks job to CI workflow

### DIFF
--- a/.github/workflows/build-push-deploy.yml
+++ b/.github/workflows/build-push-deploy.yml
@@ -15,9 +15,28 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  quality-checks:
+    name: Run quality checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.2.21"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run lint
+        run: bun run lint
+
   build-and-push:
     name: Build and push image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04-arm64
+    needs: quality-checks
     outputs:
       image_tags: ${{ steps.meta.outputs.tags }}
     steps:
@@ -26,9 +45,6 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-
-      - name: Set up QEMU (arm64 build)
-        uses: docker/setup-qemu-action@v3
 
       - name: Log in to GHCR
         uses: docker/login-action@v3


### PR DESCRIPTION
## Summary
- add a quality-checks job to run Bun linting before building images
- configure build-and-push job to depend on successful quality checks
- run the Docker build job on GitHub's Arm runner so QEMU is no longer required

## Testing
- not run (workflow change only)

------
https://chatgpt.com/codex/tasks/task_e_68ccc1c4834c832ca20207c426e2e41d